### PR TITLE
Using 'vagrant' branch of servioticy-brokers

### DIFF
--- a/puppet/manifests/bridge.pp
+++ b/puppet/manifests/bridge.pp
@@ -5,7 +5,7 @@ vcsrepo { "/opt/servioticy-bridge":
   group    => 'vagrant',
   require  => [ Package["git"], Package['forever'] ],
   source   => "https://github.com/servioticy/servioticy-brokers.git",
-  revision => 'master'
+  revision => 'vagrant'
 } 
 #->
 #exec { "run_bridge":


### PR DESCRIPTION
MQTT/Stomp - API bridge couldn't work, because it was pointing to the online API (api.servioticy.com). This push requests changes the 'servioticy-brokers' branch, so it has the correct URLs.
Needs supervision.
